### PR TITLE
Update install-and-configure-client-linux.md

### DIFF
--- a/doc_source/install-and-configure-client-linux.md
+++ b/doc_source/install-and-configure-client-linux.md
@@ -113,7 +113,7 @@ Before you can use the AWS CloudHSM client to connect to your cluster, you must 
 
 **To edit the client configuration**
 
-1. Copy your issuing certificate—[the one that you used to sign the cluster's certificate](initialize-cluster.md#sign-csr)—to the following location on the client instance: `/opt/cloudhsm/etc/customerCA.crt`\. You need AWS account root user permissions on the client instance to copy your certificate to this location\. 
+1. Copy your issuing certificate—[the one that you used to sign the cluster's certificate](initialize-cluster.md#sign-csr)—to the following location on the client instance: `/opt/cloudhsm/etc/customerCA.crt`\. You need root user permissions on the client instance to copy your certificate to this location\. 
 
 1. Use the following [configure](configure-tool.md) command to update the configuration files for the AWS CloudHSM client and command line tools, specifying the IP address of the HSM in your cluster\. To get the HSM's IP address, view your cluster in the [AWS CloudHSM console](https://console.aws.amazon.com/cloudhsm/), or run the [describe\-clusters](https://docs.aws.amazon.com/cli/latest/reference/cloudhsmv2/describe-clusters.html) AWS CLI command\. In the command's output, the HSM's IP address is the value of the `EniIp` field\. If you have more than one HSM, choose the IP address for any of the HSMs; it doesn't matter which one\. 
 


### PR DESCRIPTION
*Issue #21 , 

*Description of changes:*

Instead of "AWS account root user permissions", the customer needs root permissions (root user) in the operation system to copy the certificate to the location. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
