### PR TITLE
changed package names from httpd24 mod24_ssl to httpd mod_ssl since t…

### DIFF
--- a/doc_source/ssl-offload-prerequisites.md
+++ b/doc_source/ssl-offload-prerequisites.md
@@ -23,7 +23,7 @@ To set up web server SSL/TLS offload with AWS CloudHSM, you need the following:
       + To install Apache, run the following command\.
 
         ```
-        sudo yum install -y httpd24 mod24_ssl
+        sudo yum install -y httpd mod_ssl
         ```
 
    1. [Install and configure the OpenSSL engine](openssl-library-install.md#install-openssl-library)\.


### PR DESCRIPTION
…here is no httpd24 mod24_ssl packages in Amazon Linux 2 repos

*Issue #, if available:*

*Description of changes:*

Hi every one, I just configured CloudHSM with NGINX and Apache HTTPD on Amazon Linux 2, documentation regarding NGINX was fine except you forgot to mention `systemctl daemon-reload` after applying changes on systemd files:
https://github.com/awsdocs/aws-cloudhsm-user-guide/blob/master/doc_source/ssl-offload-configure-web-server.md
But there are couple of problems regarding Apache HTTPD:
1) There are no packages called `httpd24 mod24_ssl` anymore, I changed them in this pull request to `httpd mod_ssl`.
2) In file ssl-offload-configure-web-server.md, line 308, the correct place for Apache HTTPD envvars on Amazon Linux 2 is `/etc/sysconfig/httpd` and its different for Debian/Ubuntu distributions.
3) The same file line 317 `export n3fips_password=<CU user name>:<password>` is incorrect and it should be `n3fips_password=<CU user name>:<password>` without export word.


I don't know how to fix issue number 2 and 3 since its different for Debian/Ubuntu family and Amazon Linux 2 (Centos/RHEL) family distros, can you please help me on this?

All my changes are based on my working CloudHSM client and NGINX/Apache HTTPD on Amazon Linux 2. 

```
cat /etc/os-release
NAME="Amazon Linux"
VERSION="2"
ID="amzn"
ID_LIKE="centos rhel fedora"
VERSION_ID="2"
PRETTY_NAME="Amazon Linux 2"
ANSI_COLOR="0;33"
CPE_NAME="cpe:2.3:o:amazon:amazon_linux:2"
HOME_URL="https://amazonlinux.com/"
```

```
uname -a
Linux hsm.example.net 4.14.133-113.112.amzn2.x86_64 #1 SMP Tue Jul 30 18:29:50 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux
```

```
rpm -qa | grep -i httpd
httpd-filesystem-2.4.39-1.amzn2.0.1.noarch
generic-logos-httpd-18.0.0-4.amzn2.noarch
httpd-tools-2.4.39-1.amzn2.0.1.x86_64
httpd-2.4.39-1.amzn2.0.1.x86_64
```
```
rpm -qa | grep -i nginx
nginx-filesystem-1.12.2-3.el7.noarch
nginx-mod-http-xslt-filter-1.12.2-3.el7.x86_64
nginx-mod-stream-1.12.2-3.el7.x86_64
nginx-mod-http-perl-1.12.2-3.el7.x86_64
nginx-mod-mail-1.12.2-3.el7.x86_64
nginx-mod-http-geoip-1.12.2-3.el7.x86_64
nginx-1.12.2-3.el7.x86_64
nginx-mod-http-image-filter-1.12.2-3.el7.x86_64
nginx-all-modules-1.12.2-3.el7.noarch
```
```
rpm -qa | grep -i ssl
openssl-1.0.2k-16.amzn2.1.1.x86_64
openssl-libs-1.0.2k-16.amzn2.1.1.x86_64
mod_ssl-2.4.39-1.amzn2.0.1.x86_64
python-backports-ssl_match_hostname-3.5.0.1-1.amzn2.noarch
```

Thanks a lot.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
