### PR TITLE
Clarify passphrase, `my-key-pair.pem` permissions

### DIFF
--- a/doc_source/initialize-cluster.md
+++ b/doc_source/initialize-cluster.md
@@ -5,6 +5,8 @@ Complete the steps in the following topics to initialize your AWS CloudHSM clust
 **Note**  
 Before you initialize the cluster, review the process by which you can [verify the identity and authenticity of the HSMs](verify-hsm-identity.md)\. This process is optional and works only until a cluster is initialized\. After the cluster is initialized, you cannot use this process to get your certificates or verify the HSMs\. 
 
+Also, you must change the permissions on the `my-key-pair.pem` file you created earlier, to more restrictive permissions (chmod 400 or chmod 600). Otherwise, accessing your instance will be accompanied by warnings that the `.pem` file is too accessible.
+
 **Topics**
 + [Get the Cluster CSR](#get-csr)
 + [Sign the CSR](#sign-csr)
@@ -58,6 +60,8 @@ Currently, you must create a self\-signed signing certificate and use it to sign
 Use the following command to create a private key\. For a production cluster, the key should be created in a secure manner using a trusted source of randomness\. We recommend that you use a secured offsite and offline HSM or the equivalent\. Store the key safely\. If you can demonstrate that you own the key, you can also demonstrate that you own the cluster and the data it contains\. 
 
 During development and test, you can use any convenient tool \(such as OpenSSL\) to create and sign the cluster certificate\. The following example shows you how to create a key\. After you have used the key to create a self\-signed certificate \(see below\), you should store it in a safe manner\. To sign into your AWS CloudHSM instance, the certificate must be present, but the private key does not\. You use the key only for specific purposes such as restoring from a backup\. 
+
+When asked to `Enter passphrase for customerCA.key`, create a passphrase and enter it\.
 
 ```
 $ openssl genrsa -aes256 -out customerCA.key 2048

--- a/doc_source/initialize-cluster.md
+++ b/doc_source/initialize-cluster.md
@@ -5,7 +5,7 @@ Complete the steps in the following topics to initialize your AWS CloudHSM clust
 **Note**  
 Before you initialize the cluster, review the process by which you can [verify the identity and authenticity of the HSMs](verify-hsm-identity.md)\. This process is optional and works only until a cluster is initialized\. After the cluster is initialized, you cannot use this process to get your certificates or verify the HSMs\. 
 
-Also, you must change the permissions on the `my-key-pair.pem` file you created earlier, to more restrictive permissions (chmod 400 or chmod 600). Otherwise, accessing your instance will be accompanied by warnings that the `.pem` file is too accessible.
+Also, you must change the permissions on the `my-key-pair.pem` file you created earlier, to more restrictive permissions (chmod 400 or chmod 600)\. Otherwise, accessing your instance will be accompanied by warnings that the `.pem` file is too accessible\.
 
 **Topics**
 + [Get the Cluster CSR](#get-csr)
@@ -61,7 +61,7 @@ Use the following command to create a private key\. For a production cluster, th
 
 During development and test, you can use any convenient tool \(such as OpenSSL\) to create and sign the cluster certificate\. The following example shows you how to create a key\. After you have used the key to create a self\-signed certificate \(see below\), you should store it in a safe manner\. To sign into your AWS CloudHSM instance, the certificate must be present, but the private key does not\. You use the key only for specific purposes such as restoring from a backup\. 
 
-When asked to `Enter passphrase for customerCA.key`, create a passphrase and enter it\.
+When asked to `Enter passphrase for customerCA.key`, create a pass phrase and enter it\.
 
 ```
 $ openssl genrsa -aes256 -out customerCA.key 2048


### PR DESCRIPTION
Add instructions to clarify that the user is creating the passphrase for the customerCA.key, not entering one previously created elsewhere.  Alert user to change permissions on the `my-key-pair.pem` file created earlier.

*Issue #, if available:*
#32
*Description of changes:*

Added instructions as described above. 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
